### PR TITLE
Resized About window

### DIFF
--- a/SecureDesktop-GUI/About.Designer.cs
+++ b/SecureDesktop-GUI/About.Designer.cs
@@ -104,7 +104,7 @@
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.BackColor = System.Drawing.SystemColors.Window;
-            this.ClientSize = new System.Drawing.Size(359, 180);
+            this.ClientSize = new System.Drawing.Size(371, 192);
             this.ControlBox = false;
             this.Controls.Add(this.labelCreator);
             this.Controls.Add(this.labelVersion);
@@ -115,6 +115,7 @@
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
             this.Name = "About";
             this.ShowIcon = false;
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.Text = "About";
             ((System.ComponentModel.ISupportInitialize)(this.icon)).EndInit();
             this.ResumeLayout(false);


### PR DESCRIPTION
Resized About window because the OK button did not fit, and changed the StartPosition to be CenterParent.

Before:
![before](https://cloud.githubusercontent.com/assets/11020536/9429922/6e74709c-49e9-11e5-9ae8-8c99fea0ebb5.png)

After:
![after](https://cloud.githubusercontent.com/assets/11020536/9429923/76ce497a-49e9-11e5-9d21-32e8bb382994.png)
